### PR TITLE
define-function/single-callback macro, 64-bit chez 9.4.1

### DIFF
--- a/glut.sls
+++ b/glut.sls
@@ -286,7 +286,7 @@
     (syntax-rules (callback)
       ((_ ret name ((callback c-ret c-params)))
        (define name
-         (let ((f (foreign-procedure (symbol->string 'name) (int) ret)))
+         (let ((f (foreign-procedure (symbol->string 'name) (void*) ret)))
            (lambda (proc)
              (let ((code (foreign-callable proc c-params c-ret)))
                (lock-object code)


### PR DESCRIPTION
On OSX, with a 64-bit chez 9.4.1 , a basic example using glutReshapeFunc was erroring with:

```
Exception in f: invalid foreign-procedure argument 4360967592
```

This is readily fixed by changing the `define-function/single-callback` macro to create a foreign-procedure that takes a void\* instead of int.

Maybe an int was ok on x86 32bit, on osx 64-bit a void\* will be 64bits,
and a void\* should be the correct size on either 32 or 64 bit.
